### PR TITLE
docs: update keymap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ya pack -a Ape/smart-enter
 Create `~/.config/yazi/keymap.toml` and add:
 
 ```
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on   = "<Enter>"
 run  = "plugin smart-enter"
 desc = "Enter the child directory, or open the file"


### PR DESCRIPTION
I also updated the part in the README that is intented to be copied to the `keymap.toml` file, cause it uses and old syntax.

see docs here: https://yazi-rs.github.io/docs/configuration/keymap#mgr